### PR TITLE
RetryFailure currError should use = not :=

### DIFF
--- a/failure.go
+++ b/failure.go
@@ -16,7 +16,7 @@ func RetryFailure(tries int) FailureFunc {
 	return func(err error, step *Step, context Context) error {
 		var currError error
 		for tries > 0 {
-			currError := step.Run(context)
+			currError = step.Run(context)
 			if currError == nil {
 				return nil
 			}


### PR DESCRIPTION
Use := is redeclared the variable.
